### PR TITLE
Fix hidden content on quest page

### DIFF
--- a/src/pages/quest.tsx
+++ b/src/pages/quest.tsx
@@ -37,7 +37,6 @@ export default function QuestPage() {
   const size = useContext(ResponsiveContext);
   const { toasts, addToast } = useToaster();
   const isMobile = size === 'small';
-  const isDesktop = size === 'large';
 
   const showToaster = ({ toast }: IOnSubmitProps) => addToast(toast);
 
@@ -51,7 +50,6 @@ export default function QuestPage() {
           pad={{ vertical: 'large', horizontal: 'xlarge' }}
           background="white"
           gap="30px"
-          height={isDesktop ? 'calc(100vh - 450px)' : undefined}
         >
           <ToasterList toasts={toasts} />
           <Box gap="large" width={isMobile ? '300px' : undefined}>


### PR DESCRIPTION
## Description
Fixes an issue on the quest page where content is hidden for large screen sizes.

## Notes 
- Removed a line of code that conditionally sets the content height when the screen is large. 
- The change does not affect other screen sizes.
- I tested this on mobile and it looks the same as before.

## Screenshots
Before the change
![image](https://github.com/FLock-io/interface/assets/34484576/04db556f-0b2f-4dba-9795-a185efcf3d69)

After the change
![image](https://github.com/FLock-io/interface/assets/34484576/e7e25050-43f8-45d6-90fa-b473ea82f069)

## About me
I am a React dev looking at the FLock.io codebase for the first time. I noticed this glaring issue and thought I would push a quick fix. 

